### PR TITLE
Set min level to 90% instead of 89

### DIFF
--- a/goodwe/et.py
+++ b/goodwe/et.py
@@ -355,7 +355,7 @@ class ET(Inverter):
         return 100 - await self.read_setting('battery_discharge_depth')
 
     async def set_ongrid_battery_dod(self, dod: int) -> None:
-        if 0 <= dod <= 89:
+        if 0 <= dod <= 90:
             await self.write_setting('battery_discharge_depth', 100 - dod)
 
     def sensors(self) -> Tuple[Sensor, ...]:


### PR DESCRIPTION
Title says it all. 
Spent some hours figuring out why I can't set it to 90, while in the app, I can even set it to 95.
If possible, 95 is also an option, instead of 90. Just let me know and I'll adjust the PR.