### PR TITLE
Catch no model number and allow for discovery to be disabled explicitly 

### DIFF
--- a/goodwe/__init__.py
+++ b/goodwe/__init__.py
@@ -28,7 +28,7 @@ DT_MODEL_TAGS = ["DTU", "MSU", "DTN", "DSN", "PSB", "PSC"]
 _SUPPORTED_PROTOCOLS = [ET, DT, ES]
 
 
-async def connect(host: str, family: str = None, comm_addr: int = 0, timeout: int = 1, retries: int = 3) -> Inverter:
+async def connect(host: str, family: str = None, comm_addr: int = 0, timeout: int = 1, retries: int = 3, discover: bool = True) -> Inverter:
     """Contact the inverter at the specified host/port and answer appropriate Inverter instance.
 
     The specific inverter family/type will be detected automatically, but it can be passed explicitly.
@@ -48,7 +48,7 @@ async def connect(host: str, family: str = None, comm_addr: int = 0, timeout: in
         inv = ES(host, comm_addr, timeout, retries)
     elif family in DT_FAMILY:
         inv = DT(host, comm_addr, timeout, retries)
-    else:
+    elif discover:
         return await discover(host, timeout, retries)
 
     logger.debug("Connecting to %s family inverter at %s.", family, host)

--- a/goodwe/dt.py
+++ b/goodwe/dt.py
@@ -133,7 +133,10 @@ class DT(Inverter):
     async def read_device_info(self):
         response = await self._read_from_socket(self._READ_DEVICE_VERSION_INFO)
         response = response[5:-2]
-        self.model_name = response[22:32].decode("ascii").rstrip()
+        try:
+            self.model_name = response[22:32].decode("ascii").rstrip()
+        except:
+            print("No model name sent from the inverter.")
         self.serial_number = response[6:22].decode("ascii")
         self.dsp1_sw_version = read_unsigned_int(response, 66)
         self.dsp2_sw_version = read_unsigned_int(response, 68)


### PR DESCRIPTION
Related to https://github.com/mletenay/home-assistant-goodwe-inverter/pull/149

My GW5000D-NS does not return a Model Number (All FF's). Added a try catch as it appears that the model number isn't used anywhere elsewhere.

Also added an explicit switch to disable discovery to resolve my other issue of the wifi module disconnecting. I didn't end up implementing this in the HASS GUI as if the model family is set discovery is skipped, however it may be useful in the future and is not a breaking change as far as I know.