### PR TITLE
Add support for GW29.9K-ET

### DIFF
--- a/goodwe/model.py
+++ b/goodwe/model.py
@@ -14,7 +14,7 @@ SINGLE_PHASE_MODELS = ["DSN", "DST", "NSU", "SSN", "SST", "SSX", "SSY",  # DT
                        "ESN", "EMN", "ERN", "EBN", "HLB", "HMB", "HBB", "SPN"]  # ES Gen 2
 
 MPPT3_MODELS = ["MSU", "MST", "PSC",
-                "25KET", "29KET", "30KET"]
+                "25KET", "29KET", "29K9ET", "30KET"]
 
 MPPT4_MODELS = ["HSB"]
 


### PR DESCRIPTION
Hi,

We are using a GW29.9K-ET (see https://de.goodwe.com/Ftp/Downloads/Datasheet/DE/GW_ET%2015-30kW_Datasheet_EMEA-DE.pdf) and it would be great if your library would support that model as well.

Many thanks and thank you for your great library!