### PR TITLE
feat: add DIAG_STATUS_CODE 30

### DIFF
--- a/goodwe/const.py
+++ b/goodwe/const.py
@@ -262,6 +262,7 @@ DIAG_STATUS_CODES: dict[int, str] = {
     26: "Real power limit set",
     27: "DC output on",
     28: "SOC protect off",
+    30: "BMS: Emergency charging",
 }
 
 BMS_ALARM_CODES: dict[int, str] = {


### PR DESCRIPTION
Today I noticed that after discharging the battery to a low level, the inverter started charging it using all available power which lasted until reaching 10%, During that time, there was a diagnose code `err30`, so I'm assuming it's a forced or emergency charging requested by BMS. 
A different name (or an official one if available) is welcome.