### PR TITLE
feat: Add 25KMT to MPPT3_MODELS for 3-MPPT detection

### DIFF
--- a/goodwe/model.py
+++ b/goodwe/model.py
@@ -22,7 +22,7 @@ SINGLE_PHASE_MODELS = ("DSN", "DST", "NSU", "SSN", "SST", "SSX", "SSY",  # DT
                        "ESN", "EMN", "ERN", "EBN", "HLB", "HMB", "HBB", "SPN")  # ES Gen 2
 
 MPPT3_MODELS = ("MSU", "MST", "PSC", "MSC",
-                "25KET", "29K9ET")
+                "25KET", "29K9ET", "25KMT")
 
 MPPT4_MODELS = ("HSB",)
 


### PR DESCRIPTION
 This PR adds the 25KMT model to the MPPT3_MODELS list. This change is necessary to correctly detect and handle inverters with 3 MPPT (Maximum Power Point Tracking) inputs, specifically for the 25KMT model.

This ensures that the system can properly read and interpret data from these inverters, improving compatibility and data accuracy.