### PR TITLE
Fix required macOS permissions for inverter search

### DIFF
--- a/goodwe/protocol.py
+++ b/goodwe/protocol.py
@@ -121,9 +121,11 @@ class UdpInverterProtocol(InverterProtocol, asyncio.DatagramProtocol):
 
     async def _connect(self) -> None:
         if not self._transport or self._transport.is_closing():
+            allow_broadcast = platform.system() == "Darwin" and self._host == "255.255.255.255"
             self._transport, self.protocol = await asyncio.get_running_loop().create_datagram_endpoint(
                 lambda: self,
                 remote_addr=(self._host, self._port),
+                allow_broadcast=allow_broadcast,
             )
 
     def connection_made(self, transport: asyncio.DatagramTransport) -> None:


### PR DESCRIPTION
macOS requires the allow_broadcast flag to be set to enable permissions to send to the broadcast domain. Without this, search_inverters() will give a permission denied error, even when run as root.