### PR TITLE
ES: verify eco mode schedule writes and fall back to V1 registers (GW5048D-ES fw 2323G)

### DIFF
--- a/goodwe/es.py
+++ b/goodwe/es.py
@@ -235,6 +235,17 @@ class ES(Inverter):
         Integer("fast_charging_soc", 47546, "Fast Charging SoC", "%", Kind.BAT),
     )
 
+    _ECO_MODE_SETTINGS: tuple[str, ...] = (
+        "eco_mode_1",
+        "eco_mode_1_switch",
+        "eco_mode_2",
+        "eco_mode_2_switch",
+        "eco_mode_3",
+        "eco_mode_3_switch",
+        "eco_mode_4",
+        "eco_mode_4_switch",
+    )
+
     def __init__(
         self,
         host: str,
@@ -245,6 +256,10 @@ class ES(Inverter):
     ):
         super().__init__(host, port, comm_addr if comm_addr else 0xF7, timeout, retries)
         self._settings: dict[str, Sensor] = {s.id_: s for s in self.__all_settings}
+        # V1 eco mode sensors kept aside when V2 is detected, so eco mode can
+        # fall back to the legacy registers when a schedule write does not
+        # stick (seen on GW5048D-ES fw 2323G under concurrent polling).
+        self._eco_mode_v1_fallback: dict[str, Sensor] | None = None
 
     def _supports_eco_mode_v2(self) -> bool:
         if self.arm_version < 14:
@@ -275,6 +290,9 @@ class ES(Inverter):
             logger.exception("Error decoding firmware version %s.", self.firmware)
 
         if self._supports_eco_mode_v2():
+            self._eco_mode_v1_fallback = {
+                sid: self._settings[sid] for sid in self._ECO_MODE_SETTINGS
+            }
             self._settings.update({s.id_: s for s in self.__settings_arm_fw_14})
         if self.arm_version >= 19:
             self._settings.update({s.id_: s for s in self.__settings_arm_fw_19})
@@ -446,10 +464,69 @@ class ES(Inverter):
                 await self.write_setting(
                     "eco_mode_1", eco_mode.encode_discharge(eco_mode_power)
                 )
+            if not await self._eco_mode_write_verified(operation_mode, eco_mode_power):
+                await self._eco_mode_fallback_write(
+                    operation_mode, eco_mode_power, eco_mode_soc
+                )
             await self.write_setting("eco_mode_2_switch", 0)
             await self.write_setting("eco_mode_3_switch", 0)
             await self.write_setting("eco_mode_4_switch", 0)
             await self._set_eco_mode()
+
+    async def _eco_mode_write_verified(
+        self, operation_mode: OperationMode, eco_mode_power: int
+    ) -> bool:
+        """Read eco mode group 1 back and check it reflects the requested schedule."""
+        try:
+            readback = await self._read_setting(self._settings.get("eco_mode_1"))
+            if operation_mode == OperationMode.ECO_CHARGE:
+                return (
+                    readback.is_eco_charge_mode()
+                    and abs(readback.get_power() or 0) == eco_mode_power
+                )
+            return (
+                readback.is_eco_discharge_mode()
+                and abs(readback.get_power() or 0) == eco_mode_power
+            )
+        except (AttributeError, TypeError, ValueError, InverterError):
+            return False
+
+    async def _eco_mode_fallback_write(
+        self, operation_mode: OperationMode, eco_mode_power: int, eco_mode_soc: int
+    ) -> None:
+        """Fall back to the V1 eco mode registers when the schedule write did not stick.
+
+        On some units the eco schedule write is silently accepted but never
+        surfaces in the inverter's active schedule (observed on GW5048D-ES
+        fw 2323G, serial 5xxxxESUxxxxxxxx, while the inverter was being polled
+        concurrently - the typical Home Assistant setup). A/B testing on that
+        unit showed AA55 multi-register writes are silently dropped whenever
+        another client polls the inverter, while Modbus multi-register writes
+        are reliable under identical conditions. The fallback therefore writes
+        the legacy V1 group at 0x701 with a Modbus multi-register write and
+        verifies the result again.
+        """
+        if self._eco_mode_v1_fallback is None:
+            raise InverterError("Failed to apply eco mode schedule.")
+        logger.warning(
+            "Eco mode V2 registers did not accept the schedule "
+            "(model %s, serial %s, firmware %s), falling back to eco mode V1 registers.",
+            self.model_name,
+            self.serial_number,
+            self.firmware,
+        )
+        self._settings.update(self._eco_mode_v1_fallback)
+        self._eco_mode_v1_fallback = None
+        eco_mode: EcoMode | Sensor = self._settings.get("eco_mode_1")
+        if operation_mode == OperationMode.ECO_CHARGE:
+            raw_value = eco_mode.encode_charge(eco_mode_power, eco_mode_soc)
+        else:
+            raw_value = eco_mode.encode_discharge(eco_mode_power)
+        await self._read_from_socket(
+            self._write_multi_command(eco_mode.offset, raw_value)
+        )
+        if not await self._eco_mode_write_verified(operation_mode, eco_mode_power):
+            raise InverterError("Failed to apply eco mode schedule.")
 
     async def get_ems_mode(self) -> EMSMode:
         raise InverterError("Operation not supported.")


### PR DESCRIPTION
## Summary

On a **GW5048D-ES** (fw `2323G`, ESU serial, dsp1=23 / arm=16=`G`), the eco mode schedule write issued by `set_operation_mode(ECO_CHARGE/ECO_DISCHARGE)` can be **silently dropped**: the inverter acknowledges the write (no exception raised), but the active eco schedule never changes. The battery then sits in standby (`work_mode=3` with an empty/inactive eco group) while the caller — e.g. the Home Assistant integration — believes eco charge/discharge is active and shows the optimistic state.

This PR makes `set_operation_mode()` **read the eco group back after writing** it. If the schedule did not stick, it retries once via the **legacy V1 registers at 0x701 using a Modbus multi-register write**, and verifies again (raising `InverterError` if that also fails). Units where the primary write path works see no behavior change — the fallback only runs when verification fails.

## Evidence (hardware A/B test)

All observations from a GW5048D-ES, fw `2323G`, serial `5xxxxESUxxxxxxxx`, Modbus-UDP :8899, while building a closed-loop battery steering setup with the HA integration (polling every 5 s):

| Test | Concurrent polling | Write route | Result |
|---|---|---|---|
| `set_operation_mode(ECO_DISCHARGE, 40)` | **off** | AA55 multi-write @ 0x701 (V1 defs forced) | ✅ schedule lands, battery discharges within seconds |
| identical call | **on** | AA55 multi-write @ 0x701 | ❌ silently dropped — no exception, register unchanged (reproduced 3×, incl. hours of automated retries every 15 s) |
| raw `_write_multi_command(1793, EcoModeV1.encode_discharge(21))` | **on** | Modbus multi-write @ 0x701 | ✅ lands first try (`0:0-23:59 21% On` on read-back) |
| `set_operation_mode(ECO_DISCHARGE, 20)` with this PR | **on** | primary path + verify | ✅ verified OK, no fallback needed |

Single-register AA55 writes (e.g. `work_mode`) were never observed to drop — only multi-register AA55 writes under concurrent traffic. That combination is exactly what the HA integration produces in normal operation, which is why users of this unit see eco charge/discharge "accepted" but doing nothing (battery stays in standby, HA select shows the eco mode).

Possibly related reports on the HA integration: mletenay/home-assistant-goodwe-inverter#183, mletenay/home-assistant-goodwe-inverter#177, mletenay/home-assistant-goodwe-inverter#252.

## What the change does

- `read_device_info()` keeps the V1 eco sensor definitions aside when V2 is detected (`_eco_mode_v1_fallback`).
- After the eco group write in `set_operation_mode()`, `_eco_mode_write_verified()` reads group 1 back and checks `is_eco_charge_mode()`/`is_eco_discharge_mode()` plus the power value.
- On mismatch, `_eco_mode_fallback_write()` swaps the eco settings to the V1 definitions, rewrites the group via `_write_multi_command()` (Modbus), and verifies again.
- `122/122` existing tests pass; no public API change.

Happy to adjust the approach (e.g. verify-only without fallback, or gating differently) if you prefer — I kept the diff minimal and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01683sQDV8nefwHsAnTUviF9
