### PR TITLE
Add Modbus/TCP port 502 fallback to discover()

### DIFF
--- a/goodwe/__init__.py
+++ b/goodwe/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from .const import GOODWE_UDP_PORT
+from .const import GOODWE_TCP_PORT, GOODWE_UDP_PORT
 from .dt import DT
 from .es import ES
 from .et import ET
@@ -124,7 +124,7 @@ async def discover(
         except InverterError as ex:
             failures.append(ex)
 
-    # Probe inverter specific protocols
+    # Probe inverter specific protocols on the default port
     for inv in [ET, DT, ES]:
         i = inv(host, port, 0, timeout, retries)
         try:
@@ -140,6 +140,27 @@ async def discover(
             return i
         except InverterError as ex:
             failures.append(ex)
+
+    # Fallback to Modbus/TCP on port 502 for v2.0 LAN modules (WLA0000-01-00P)
+    # which do not respond on the default UDP port 8899
+    if port == GOODWE_UDP_PORT:
+        logger.debug("UDP probes failed, trying Modbus/TCP on port 502.")
+        for inv in [ET, DT, ES]:
+            i = inv(host, GOODWE_TCP_PORT, 0, timeout, retries)
+            try:
+                logger.debug("Probing %s inverter at %s:%s.", inv.__name__, host, GOODWE_TCP_PORT)
+                await i.read_device_info()
+                await i.read_runtime_data()
+                logger.debug(
+                    "Detected %s family inverter %s, S/N:%s.",
+                    inv.__name__,
+                    i.model_name,
+                    i.serial_number,
+                )
+                return i
+            except InverterError as ex:
+                failures.append(ex)
+
     raise InverterError(
         "Unable to connect to the inverter at "
         f"host={host}, or your inverter is not supported yet.\n"


### PR DESCRIPTION
## PR: Add Modbus/TCP port 502 fallback to `discover()`

### Problem

`goodwe.connect(host)` fails to discover inverters that use the v2.0 LAN+WiFi communication dongle (model **WLA0000-01-00P**). The library defaults to UDP port 8899 for discovery, but these newer dongles speak **Modbus/TCP on port 502** and **do not respond on UDP 8899** (that port is reserved for DTLS-encrypted communication).

The `discover()` function tries:
1. AA55 discovery command on UDP 8899 → no response
2. Modbus RTU over UDP for each family (ET, DT, ES) → no response

...then gives up, never attempting TCP port 502.

Users must manually pass `port=502` to `connect()`, which is not obvious.

### Fix

Added a TCP port 502 fallback loop in `discover()` that runs **only when** the default UDP port was used and all UDP probes failed. The fallback tries each inverter family (ET, DT, ES) over Modbus/TCP on port 502.

This means `connect(host)` now works automatically for both:
- **Older inverters** with WiFi dongle → UDP 8899 (existing behavior, unchanged)
- **Newer inverters** with v2.0 LAN module → TCP 502 (new fallback)

### Changes

**`goodwe/__init__.py`**
- Import `GOODWE_TCP_PORT` from `.const`
- Added TCP port 502 fallback loop in `discover()` after the UDP probes fail

### Testing

Tested against a **GW5K-DNS-G40** inverter (DT family) with WLA0000-01-00P module at `192.168.0.40`:

```python
# Before fix: fails with InverterError
inverter = await goodwe.connect("192.168.0.40")

# Before fix: works only with explicit port
inverter = await goodwe.connect("192.168.0.40", port=502)

# After fix: works without specifying port
inverter = await goodwe.connect("192.168.0.40")
# → SUCCESS: GW5K-DNS-G40, S/N: 55000NBA263L1473
```

### Related

The `search_inverters()` broadcast (port 48899) works with the v2.0 dongle but returns a **different response format** than the older WiFi dongle:

| Dongle | Response Format |
|---|---|
| Old WiFi dongle | `<ip>,<mac>,<name>` |
| v2.0 LAN module | `dongle@<sn>,dtls_port:<port>,<inverter_sn>` |

This is a separate issue — the IP is known from the UDP packet source but `search_inverters()` only returns the response body. This PR does not address that.

### Commit

```
ea87d6e - Add Modbus/TCP port 502 fallback to discover()
```