### PR TITLE
Fix hardcoded 100% SOC limit in EcoModeV2 encode_discharge

### DIFF
--- a/goodwe/et.py
+++ b/goodwe/et.py
@@ -1084,7 +1084,7 @@ class ET(Inverter):
                 )
             else:
                 await self.write_setting(
-                    "eco_mode_1", eco_mode.encode_discharge(eco_mode_power)
+                    "eco_mode_1", eco_mode.encode_discharge(eco_mode_power, eco_mode_soc)
                 )
             await self.write_setting("eco_mode_2_switch", 0)
             await self.write_setting("eco_mode_3_switch", 0)

--- a/goodwe/sensor.py
+++ b/goodwe/sensor.py
@@ -522,7 +522,7 @@ class EcoMode(ABC):
         """Answer bytes representing all the time enabled charging eco-mode group"""
 
     @abstractmethod
-    def encode_discharge(self, eco_mode_power: int) -> bytes:
+    def encode_discharge(self, eco_mode_power: int, eco_mode_soc: int = 100) -> bytes:
         """Answer bytes representing all the time enabled discharging eco-mode group"""
 
     @abstractmethod
@@ -608,7 +608,7 @@ class EcoModeV1(Sensor, EcoMode):
         """Answer bytes representing all the time enabled charging eco-mode group"""
         return bytes.fromhex("0000173b{:04x}ff7f".format((-1 * abs(eco_mode_power)) & (2 ** 16 - 1)))
 
-    def encode_discharge(self, eco_mode_power: int) -> bytes:
+    def encode_discharge(self, eco_mode_power: int, eco_mode_soc: int = 100) -> bytes:
         """Answer bytes representing all the time enabled discharging eco-mode group"""
         return bytes.fromhex("0000173b{:04x}ff7f".format(abs(eco_mode_power)))
 
@@ -734,11 +734,12 @@ class Schedule(Sensor, EcoMode):
                 eco_mode_soc,
                 0 if self.schedule_type != ScheduleType.ECO_MODE_745 else 0x0fff))
 
-    def encode_discharge(self, eco_mode_power: int) -> bytes:
+    def encode_discharge(self, eco_mode_power: int, eco_mode_soc: int = 100) -> bytes:
         """Answer bytes representing all the time enabled discharging eco-mode group"""
-        return bytes.fromhex("0000173b{:02x}7f{:04x}0064{:04x}".format(
+        return bytes.fromhex("0000173b{:02x}7f{:04x}{:04x}{:04x}".format(
             255 - self.schedule_type,
             abs(self.schedule_type.encode_power(eco_mode_power)),
+            eco_mode_soc,
             0 if self.schedule_type != ScheduleType.ECO_MODE_745 else 0x0fff))
 
     def encode_off(self) -> bytes:


### PR DESCRIPTION
## Description
When the `set_operation_mode` function is called with `OperationMode.ECO_DISCHARGE` for ET/EH inverters (using `EcoModeV2` / `Schedule`), it ignores the user-specified `eco_mode_soc` parameter and incorrectly hardcodes `0064` (100% SOC) into the modbus byte string.

Because the depth-of-discharge is hardcoded to 100%, batteries sitting below 100% SOC will refuse to discharge and immediately throw a BMS "APP: Discharge current too low" limit, effectively breaking `eco_discharge` mode for discharging into the grid.

## Fix
This commit updates the `encode_discharge` signature to accept `eco_mode_soc` and dynamically formats the hex string just as `encode_charge` does, allowing users to discharge their batteries down to their specified target (e.g., 10%).
